### PR TITLE
fix(config): trust user/profile-scoped configPath, allow absolute paths (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,28 @@ Open any file matching your configured extensions. The LSP will start automatica
 
 ### Configuration File Locations
 
-The extension looks for configuration in the following order:
+For every workspace folder the extension loads, in order:
 
-1. `.vscode/lsp-proxy.json` (workspace-specific)
-2. `.lsp-proxy.json` (project root)
-3. Global configuration in VS Code settings
+1. The path in the `genericLspProxy.configPath` setting (default `.vscode/lsp-proxy.json`).
+2. `.lsp-proxy.json` in the folder root — only as a fallback when the `configPath` file does not exist.
+
+It then always also loads a **global** config file shared across all open folders:
+
+3. `lsp-proxy.json` in the extension's `globalStorage` directory. This location is per VS Code profile; its filesystem path is shown in the extension's output channel on load. Use it for servers you want available in every workspace.
+
+#### `configPath` scope and trust
+
+`genericLspProxy.configPath` is read with VS Code's setting scopes, and its scope changes how the value is resolved:
+
+- **Workspace / folder scope** (`.vscode/settings.json`, `*.code-workspace`): the value is repo-controlled and treated as untrusted. It is resolved **relative to the workspace folder** and must stay **inside** it — an absolute path or a `..` escape is rejected (logged as `Invalid configPath … escapes workspace folder … skipping`). This prevents an unverified repository from pointing the extension at an arbitrary file.
+- **User / profile scope** (your User `settings.json`): the value is set by you and is trusted. An **absolute path is allowed** and is loaded once, independent of any workspace folder — set it here to share one config across workspaces or to keep a per-profile config (e.g. a Nix-generated path). A relative user-scoped value is resolved per folder without the containment restriction.
+
+```jsonc
+// User settings.json — absolute path, shared across all workspaces / per profile
+{
+  "genericLspProxy.configPath": "/path/to/generic-lsp-proxy.json"
+}
+```
 
 ### Configuration Schema
 
@@ -266,7 +283,7 @@ Configure the extension behavior in VS Code settings (`Ctrl+,` / `Cmd+,`):
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `genericLspProxy.configPath` | string | `.vscode/lsp-proxy.json` | Path to configuration file |
+| `genericLspProxy.configPath` | string | `.vscode/lsp-proxy.json` | Path to configuration file. Workspace-scoped values must stay inside the folder; user/profile-scoped values may be absolute. See [`configPath` scope and trust](#configpath-scope-and-trust). |
 | `genericLspProxy.enableDebugLogging` | boolean | `false` | Enable detailed logging |
 
 ## 📟 Commands
@@ -377,6 +394,7 @@ task format
 | "Connection refused" | For TCP, ensure server is running on specified port |
 | "Invalid configuration" | Check JSON syntax and required fields |
 | "Server stopped" | Check server logs and restart manually |
+| "Invalid configPath … escapes workspace folder" | A workspace-scoped `configPath` must stay inside the folder. To use an absolute path, set `genericLspProxy.configPath` in your **User** settings instead of workspace settings — see [`configPath` scope and trust](#configpath-scope-and-trust). |
 
 ## 🤝 Contributing
 

--- a/src/configurationManager.ts
+++ b/src/configurationManager.ts
@@ -3,6 +3,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Logger } from './logger';
 
+/** Keep in sync with the `configPath` contributes default in package.json. */
+const DEFAULT_CONFIG_PATH = '.vscode/lsp-proxy.json';
+
 export interface LSPServerConfig {
     id?: string; // populated after load; stable identity
     languageId: string;
@@ -21,11 +24,10 @@ export interface LSPServerConfig {
 }
 
 /**
- * Resolve `p` against `folderFsPath`, returning the absolute path only if it stays
- * within `folderFsPath`. Returns `undefined` for inputs that escape the folder (via `..`)
- * or are absolute. Applied only to a *workspace/folder-scoped* `configPath` (untrusted in
- * unverified repos), so this guards path-traversal out of the workspace. A user/profile-scoped
- * value is set by the user, not the repo, and bypasses this guard (see `loadConfiguration`).
+ * Resolve `p` within `folderFsPath`; `undefined` if it escapes via `..` or is absolute. The
+ * path-containment guard (CFG-5) for untrusted (workspace/folder-scoped) configPaths, which an
+ * unverified repo could otherwise point outside the workspace; trusted user/profile-scoped values
+ * bypass it (see `loadConfiguration`).
  */
 export function resolveWithinFolder(folderFsPath: string, p: string): string | undefined {
     const resolved = path.resolve(folderFsPath, p);
@@ -59,29 +61,14 @@ export class ConfigurationManager {
             return;
         }
 
-        // A user/profile-scoped (or default) `configPath` is set by the user and is trusted:
-        // absolute paths and `..` are honored, and an absolute one is workspace-independent
-        // (loaded once, applied across all folders). A workspace/folder-scoped value is
-        // repo-controlled and stays subject to the path-containment guard (CFG-5), since an
-        // unverified repo could otherwise point it outside the workspace. Scope is read via
-        // inspect() per folder so multi-root overrides are honored.
-        const loadedAbsolute = new Set<string>();
+        const loadedTrustedAbsolutePaths = new Set<string>();
         for (const folder of workspaceFolders) {
-            const inspected = vscode.workspace
-                .getConfiguration('genericLspProxy', folder.uri)
-                .inspect<string>('configPath');
-            const configPath = inspected?.workspaceFolderValue
-                ?? inspected?.workspaceValue
-                ?? inspected?.globalValue
-                ?? inspected?.defaultValue
-                ?? '.vscode/lsp-proxy.json';
-            const trusted = inspected?.workspaceFolderValue === undefined
-                && inspected?.workspaceValue === undefined;
+            const { configPath, trusted, isAbsolute } = this.resolveConfigPathForFolder(folder);
 
-            if (trusted && path.isAbsolute(configPath)) {
-                // Workspace-independent; load once even across multiple folders.
-                if (!loadedAbsolute.has(configPath)) {
-                    loadedAbsolute.add(configPath);
+            if (trusted && isAbsolute) {
+                // Not folder-bound: the same path recurs for every folder, so load it once.
+                if (!loadedTrustedAbsolutePaths.has(configPath)) {
+                    loadedTrustedAbsolutePaths.add(configPath);
                     await this.loadTrustedConfig(configPath);
                 }
                 continue;
@@ -103,9 +90,26 @@ export class ConfigurationManager {
         this.logger.info(`Loaded ${this.configs.length} LSP configurations`);
     }
 
+    /**
+     * Effective `configPath` for a folder. `trusted` is false when a repo-controlled scope (folder
+     * or workspace) supplied it — those stay subject to the containment guard; user/global/default
+     * scopes are trusted.
+     */
+    private resolveConfigPathForFolder(folder: vscode.WorkspaceFolder): { configPath: string; trusted: boolean; isAbsolute: boolean } {
+        const inspected = vscode.workspace
+            .getConfiguration('genericLspProxy', folder.uri)
+            .inspect<string>('configPath');
+        const configPath = inspected?.workspaceFolderValue
+            ?? inspected?.workspaceValue
+            ?? inspected?.globalValue
+            ?? inspected?.defaultValue
+            ?? DEFAULT_CONFIG_PATH;
+        const trusted = inspected?.workspaceFolderValue === undefined
+            && inspected?.workspaceValue === undefined;
+        return { configPath, trusted, isAbsolute: path.isAbsolute(configPath) };
+    }
+
     private async loadConfigFromWorkspace(folder: vscode.WorkspaceFolder, configPath: string, trusted: boolean): Promise<void> {
-        // Trusted (user/profile/default) values resolve plainly; untrusted (repo-supplied)
-        // values stay within the folder via the containment guard.
         const absolutePath = trusted
             ? path.resolve(folder.uri.fsPath, configPath)
             : resolveWithinFolder(folder.uri.fsPath, configPath);
@@ -157,9 +161,9 @@ export class ConfigurationManager {
     }
 
     /**
-     * Load a user/profile-scoped absolute `configPath`. It is workspace-independent, so it is
-     * loaded once with no folder binding (its configs apply across all workspace folders).
-     * A missing file is a warning, not an error — the user may not have created it yet.
+     * Load a trusted absolute `configPath` once, unbound to any folder. A missing file warns rather
+     * than errors and — unlike an untrusted relative path — is not retried against a folder's
+     * `.lsp-proxy.json` (an explicit absolute path is honored as given).
      */
     private async loadTrustedConfig(absolutePath: string): Promise<void> {
         if (fs.existsSync(absolutePath)) {

--- a/src/configurationManager.ts
+++ b/src/configurationManager.ts
@@ -23,8 +23,9 @@ export interface LSPServerConfig {
 /**
  * Resolve `p` against `folderFsPath`, returning the absolute path only if it stays
  * within `folderFsPath`. Returns `undefined` for inputs that escape the folder (via `..`)
- * or are absolute. `configPath` is workspace-controlled (untrusted in unverified repos),
- * so this guards path-traversal out of the workspace.
+ * or are absolute. Applied only to a *workspace/folder-scoped* `configPath` (untrusted in
+ * unverified repos), so this guards path-traversal out of the workspace. A user/profile-scoped
+ * value is set by the user, not the repo, and bypasses this guard (see `loadConfiguration`).
  */
 export function resolveWithinFolder(folderFsPath: string, p: string): string | undefined {
     const resolved = path.resolve(folderFsPath, p);
@@ -58,10 +59,35 @@ export class ConfigurationManager {
             return;
         }
 
-        const configPath = vscode.workspace.getConfiguration('genericLspProxy').get<string>('configPath', '.vscode/lsp-proxy.json');
-
+        // A user/profile-scoped (or default) `configPath` is set by the user and is trusted:
+        // absolute paths and `..` are honored, and an absolute one is workspace-independent
+        // (loaded once, applied across all folders). A workspace/folder-scoped value is
+        // repo-controlled and stays subject to the path-containment guard (CFG-5), since an
+        // unverified repo could otherwise point it outside the workspace. Scope is read via
+        // inspect() per folder so multi-root overrides are honored.
+        const loadedAbsolute = new Set<string>();
         for (const folder of workspaceFolders) {
-            await this.loadConfigFromWorkspace(folder, configPath);
+            const inspected = vscode.workspace
+                .getConfiguration('genericLspProxy', folder.uri)
+                .inspect<string>('configPath');
+            const configPath = inspected?.workspaceFolderValue
+                ?? inspected?.workspaceValue
+                ?? inspected?.globalValue
+                ?? inspected?.defaultValue
+                ?? '.vscode/lsp-proxy.json';
+            const trusted = inspected?.workspaceFolderValue === undefined
+                && inspected?.workspaceValue === undefined;
+
+            if (trusted && path.isAbsolute(configPath)) {
+                // Workspace-independent; load once even across multiple folders.
+                if (!loadedAbsolute.has(configPath)) {
+                    loadedAbsolute.add(configPath);
+                    await this.loadTrustedConfig(configPath);
+                }
+                continue;
+            }
+
+            await this.loadConfigFromWorkspace(folder, configPath, trusted);
         }
 
         await this.loadGlobalConfig();
@@ -77,8 +103,12 @@ export class ConfigurationManager {
         this.logger.info(`Loaded ${this.configs.length} LSP configurations`);
     }
 
-    private async loadConfigFromWorkspace(folder: vscode.WorkspaceFolder, configPath: string): Promise<void> {
-        const absolutePath = resolveWithinFolder(folder.uri.fsPath, configPath);
+    private async loadConfigFromWorkspace(folder: vscode.WorkspaceFolder, configPath: string, trusted: boolean): Promise<void> {
+        // Trusted (user/profile/default) values resolve plainly; untrusted (repo-supplied)
+        // values stay within the folder via the containment guard.
+        const absolutePath = trusted
+            ? path.resolve(folder.uri.fsPath, configPath)
+            : resolveWithinFolder(folder.uri.fsPath, configPath);
         if (absolutePath === undefined) {
             this.logger.error(`Invalid configPath "${configPath}": escapes workspace folder ${folder.uri.fsPath}; skipping`);
             return;
@@ -123,6 +153,19 @@ export class ConfigurationManager {
             }
         } catch (error) {
             this.logger.error(`Failed to load config from ${filePath}: ${error}`);
+        }
+    }
+
+    /**
+     * Load a user/profile-scoped absolute `configPath`. It is workspace-independent, so it is
+     * loaded once with no folder binding (its configs apply across all workspace folders).
+     * A missing file is a warning, not an error — the user may not have created it yet.
+     */
+    private async loadTrustedConfig(absolutePath: string): Promise<void> {
+        if (fs.existsSync(absolutePath)) {
+            await this.loadConfigFile(absolutePath);
+        } else {
+            this.logger.warn(`configPath "${absolutePath}" not found; skipping`);
         }
     }
 

--- a/src/test/mocks/vscode.ts
+++ b/src/test/mocks/vscode.ts
@@ -55,6 +55,14 @@ export class MockWorkspaceConfiguration {
         return this.values.has(section);
     }
 
+    // Provided values are treated as user/profile-scoped (globalValue) — i.e. trusted.
+    inspect<T>(section: string): { key: string; defaultValue?: T; globalValue?: T; workspaceValue?: T; workspaceFolderValue?: T } | undefined {
+        if (!this.values.has(section)) {
+            return undefined;
+        }
+        return { key: section, globalValue: this.values.get(section) as T };
+    }
+
     update(section: string, value: any): Thenable<void> {
         this.values.set(section, value);
         return Promise.resolve();

--- a/src/test/suite/configurationManager.test.ts
+++ b/src/test/suite/configurationManager.test.ts
@@ -396,7 +396,7 @@ suite('loadConfiguration (configPath scope, #18)', () => {
             show: sandbox.stub(), dispose: sandbox.stub()
         };
         mockContext = {
-            // Points at a non-existent dir so the globalStorage config is skipped.
+            // No global config here, so the count assertions stay isolated.
             globalStorageUri: { fsPath: path.join(baseDir, 'no-global-storage') },
             subscriptions: [],
             workspaceState: { get: sandbox.stub().returns([]), update: sandbox.stub().resolves() }
@@ -452,7 +452,6 @@ suite('loadConfiguration (configPath scope, #18)', () => {
 
         await configManager.loadConfiguration();
 
-        // Dedup keeps the workspace-independent absolute path from loading per-folder.
         assert.strictEqual(configManager.getAllConfigs().length, 1);
     });
 });

--- a/src/test/suite/configurationManager.test.ts
+++ b/src/test/suite/configurationManager.test.ts
@@ -2,8 +2,10 @@ import assert from 'assert';
 import * as vscode from 'vscode';
 import * as sinon from 'sinon';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { ConfigurationManager, LSPServerConfig, resolveWithinFolder } from '../../configurationManager';
+import { MockWorkspaceFolder } from '../mocks/vscode';
 
 suite('ConfigurationManager Test Suite', () => {
     let configManager: ConfigurationManager;
@@ -351,6 +353,107 @@ suite('ConfigurationManager Test Suite', () => {
         } finally {
             await fs.promises.unlink(tempFile).catch(() => {});
         }
+    });
+});
+
+suite('loadConfiguration (configPath scope, #18)', () => {
+    // `fs.existsSync` is non-configurable and cannot be stubbed, so these exercise the real
+    // filesystem with temp dirs (mirrors the dual-python test above).
+    let configManager: ConfigurationManager;
+    let mockContext: any;
+    let mockLogger: any;
+    let sandbox: sinon.SinonSandbox;
+    let baseDir: string;
+    let userPath: string;
+
+    const validConfigJson = JSON.stringify({
+        languageId: 'nix',
+        command: 'nil',
+        fileExtensions: ['.nix']
+    });
+
+    const stubConfigScope = (inspectResult: unknown) => {
+        sandbox.stub(vscode.workspace, 'getConfiguration').returns({
+            get: (_key: string, defaultValue?: unknown) => defaultValue,
+            has: () => false,
+            update: () => Promise.resolve(),
+            inspect: () => inspectResult
+        } as any);
+    };
+
+    const escapesError = () =>
+        mockLogger.error.getCalls().some((c: any) => String(c.args[0]).includes('escapes workspace folder'));
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lsp-proxy-test-'));
+        userPath = path.join(baseDir, 'user-config.json');
+        fs.writeFileSync(userPath, validConfigJson);
+
+        mockLogger = {
+            info: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub(),
+            debug: sandbox.stub(), setDebugEnabled: sandbox.stub(),
+            show: sandbox.stub(), dispose: sandbox.stub()
+        };
+        mockContext = {
+            // Points at a non-existent dir so the globalStorage config is skipped.
+            globalStorageUri: { fsPath: path.join(baseDir, 'no-global-storage') },
+            subscriptions: [],
+            workspaceState: { get: sandbox.stub().returns([]), update: sandbox.stub().resolves() }
+        };
+        configManager = new ConfigurationManager(mockContext, mockLogger as any);
+    });
+
+    teardown(() => {
+        sandbox.restore();
+        fs.rmSync(baseDir, { recursive: true, force: true });
+    });
+
+    const makeFolder = (name: string, index = 0) => {
+        const dir = path.join(baseDir, name);
+        fs.mkdirSync(dir, { recursive: true });
+        return new MockWorkspaceFolder(dir, name, index);
+    };
+
+    test('user/profile-scoped absolute configPath is trusted and loaded', async () => {
+        sandbox.stub(vscode.workspace, 'workspaceFolders').value([makeFolder('app')]);
+        stubConfigScope({ key: 'genericLspProxy.configPath', defaultValue: '.vscode/lsp-proxy.json', globalValue: userPath });
+
+        await configManager.loadConfiguration();
+
+        assert.strictEqual(configManager.getAllConfigs().length, 1);
+        assert.strictEqual(configManager.getConfigById('nix::nil')?.command, 'nil');
+        assert.strictEqual(escapesError(), false);
+    });
+
+    test('workspace-scoped absolute configPath is rejected by the containment guard', async () => {
+        sandbox.stub(vscode.workspace, 'workspaceFolders').value([makeFolder('app')]);
+        stubConfigScope({ key: 'genericLspProxy.configPath', defaultValue: '.vscode/lsp-proxy.json', workspaceValue: userPath });
+
+        await configManager.loadConfiguration();
+
+        assert.strictEqual(configManager.getAllConfigs().length, 0);
+        assert.strictEqual(escapesError(), true);
+    });
+
+    test('workspace-scoped parent-escape configPath is rejected', async () => {
+        sandbox.stub(vscode.workspace, 'workspaceFolders').value([makeFolder('app')]);
+        stubConfigScope({ key: 'genericLspProxy.configPath', defaultValue: '.vscode/lsp-proxy.json', workspaceValue: '../user-config.json' });
+
+        await configManager.loadConfiguration();
+
+        assert.strictEqual(configManager.getAllConfigs().length, 0);
+        assert.strictEqual(escapesError(), true);
+    });
+
+    test('user-scoped absolute configPath in a multi-root workspace loads once', async () => {
+        sandbox.stub(vscode.workspace, 'workspaceFolders').value([makeFolder('a', 0), makeFolder('b', 1)]);
+        stubConfigScope({ key: 'genericLspProxy.configPath', defaultValue: '.vscode/lsp-proxy.json', globalValue: userPath });
+
+        await configManager.loadConfiguration();
+
+        // Dedup keeps the workspace-independent absolute path from loading per-folder.
+        assert.strictEqual(configManager.getAllConfigs().length, 1);
     });
 });
 

--- a/src/test/unit-test-runner.ts
+++ b/src/test/unit-test-runner.ts
@@ -41,7 +41,8 @@ const mockVscode = {
         getConfiguration: () => ({
             get: (_key: string, defaultValue?: unknown) => defaultValue,
             has: () => false,
-            update: () => Promise.resolve()
+            update: () => Promise.resolve(),
+            inspect: () => undefined
         }),
         workspaceFolders: [] as unknown[],
         getWorkspaceFolder: () => undefined,


### PR DESCRIPTION
Fixes #18.

`configPath` was always run through the workspace-containment guard, so a user-scoped absolute path (e.g. a Nix store path outside the workspace) was rejected:

```
[ERROR] Invalid configPath "/nix/store/…-generic-lsp-proxy.json": escapes workspace folder …; skipping
```

That guard only matters for workspace/folder-scoped values, which a checked-in `.vscode/settings.json` could control. We now allow a user-scoped value actually set by the user and trust it.

## Changes

- Read `configPath` per folder via `inspect()`, so the setting's scope is known.
- Workspace/folder scope stays untrusted — containment guard unchanged.
- User/profile/default scope is trusted: absolute paths and `..` are allowed. An absolute trusted path is workspace-independent, so it loads once (deduped across multi-root folders) and applies everywhere.
- A missing trusted file now warns instead of erroring.

Per-profile configs come along for free: each VS Code profile has its own User `settings.json`, so a user-scoped `configPath` is already per-profile — no `globalStorageUri` change needed.

And some README entries on the change.