### PR TITLE
fix: stop injecting --stdio into user-configured server args

### DIFF
--- a/src/lspProxyManager.ts
+++ b/src/lspProxyManager.ts
@@ -3,7 +3,6 @@ import {
     LanguageClient,
     LanguageClientOptions,
     ServerOptions,
-    TransportKind,
     StreamInfo,
     State,
     StateChangeEvent
@@ -211,8 +210,7 @@ export class LspProxyManager extends EventEmitter {
                 // is only reached for trusted workspaces, where running config.command is
                 // the extension's intended behavior.
                 shell: process.platform === 'win32'
-            },
-            transport: TransportKind.stdio
+            }
         };
     }
 

--- a/src/test/suite/lspProxyManager.test.ts
+++ b/src/test/suite/lspProxyManager.test.ts
@@ -273,9 +273,36 @@ suite('LspProxyManager Test Suite', () => {
         };
 
         const serverOptions = (lspManager as any).createServerOptions(config);
-        
+
         assert.strictEqual(serverOptions.command, 'pylsp');
         assert.deepStrictEqual(serverOptions.args, ['--verbose']);
+    });
+
+    test('should pass args through verbatim without injecting --stdio (#42)', () => {
+        const config: LSPServerConfig = {
+            languageId: 'python',
+            command: 'jedi-language-server',
+            fileExtensions: ['.py', '.pyw'],
+            args: []
+        };
+
+        const serverOptions = (lspManager as any).createServerOptions(config);
+
+        assert.deepStrictEqual(serverOptions.args, []);
+        assert.strictEqual(serverOptions.transport, undefined);
+    });
+
+    test('should not inject --stdio into a config that omits args (#42)', () => {
+        const config: LSPServerConfig = {
+            languageId: 'ruby',
+            command: 'solargraph',
+            fileExtensions: ['.rb']
+        };
+
+        const serverOptions = (lspManager as any).createServerOptions(config);
+
+        assert.deepStrictEqual(serverOptions.args, []);
+        assert.strictEqual(serverOptions.transport, undefined);
     });
 
     test('should create server options for tcp transport', () => {


### PR DESCRIPTION
Fixes #42.

`createServerOptions` set `transport: TransportKind.stdio` on the `Executable`. `vscode-languageclient/lib/node/main.js` and this mutated the arg list for that transport kind... New approach removes that default arg.

```js
const args = json.args !== undefined ? json.args.slice(0) : [];
if (transport === TransportKind.stdio) {
    args.push("--stdio");
}
...
if (transport === undefined || transport === TransportKind.stdio) {
    const serverProcess = cp.spawn(command.command, args, options);
}
```
